### PR TITLE
fix: remove hardcoded Google Maps API key, read from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_GOOGLE_MAPS_API_KEY=your-google-maps-browser-key

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ngrok
 node_modules/
 npm-debug.log
 dist/
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ Users can filter out places and their markers by name by entering filters into t
 ### Getting More Information
 
 Users can get more information about a particular place by clicking on a place in the list view or its corresponding marker. These actions will cause an info window to popup above that respective place's map marker. The info window will contain the place's image, name, phone number, rating, and yelp link provided by Yelp's API.
+
+> Note: requires a Google Maps browser key in .env (see .env.example). The key formerly committed here has been removed from source; rotate/restrict any key you deploy via Google Cloud Console (HTTP referrer restriction).

--- a/src/index.html
+++ b/src/index.html
@@ -144,18 +144,6 @@
       alt="Open Map Menu"
     />
 
-    <!-- <gmpx-api-loader
-      key="AIzaSyCiBpLlS2nUY1NlBn1tM8If10sdIGm6o8I"
-      solution-channel="GMP_GE_mapsandplacesautocomplete_v2"
-    >
-    </gmpx-api-loader>
-    <gmp-map center="40.749933,-73.98633" zoom="13" map-id="DEMO_MAP_ID">
-      <div slot="control-block-start-inline-start" class="place-picker-container">
-        <gmpx-place-picker placeholder="Enter an address"></gmpx-place-picker>
-      </div>
-      <gmp-advanced-marker></gmp-advanced-marker>
-    </gmp-map> -->
-
     <!-- Javascript Dependencies-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/knockout/knockout-3.3.0.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@
 import {Loader} from '@googlemaps/js-api-loader';
 import pWaitFor from 'p-wait-for';
 
-const API_KEY = 'AIzaSyCiBpLlS2nUY1NlBn1tM8If10sdIGm6o8I';
+const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 
 const loader = new Loader({
   apiKey: API_KEY,


### PR DESCRIPTION
## What

Removes the live Google Maps API key that was hardcoded in source and switches the app to read it from a Vite environment variable.

## Changes

- `src/main.js`: `const API_KEY` now reads `import.meta.env.VITE_GOOGLE_MAPS_API_KEY` instead of a literal key (used by the `@googlemaps/js-api-loader` config and the Places photo URL).
- `src/index.html`: deleted a commented-out `<gmpx-api-loader>`/`<gmp-map>` block that still embedded the same live key. It was a dead alternate implementation (the app loads Maps via `js-api-loader` in `main.js`), so removing it drops the key with no functional change.
- `.env.example`: added with `VITE_GOOGLE_MAPS_API_KEY=your-google-maps-browser-key`.
- `.gitignore`: added `.env` and `.env.local`.
- `README.md`: added a note about supplying the key via `.env` and rotating/restricting any deployed key.

## Verification

- `grep -rn "AIzaSy" src/` is clean on this branch.
- `VITE_GOOGLE_MAPS_API_KEY=x npm run build` exits 0.

## Note

The key stays in older commit history — this PR does not rewrite history. The owner should rotate/restrict the exposed key in the Google Cloud Console (HTTP referrer restriction) as a manual follow-up.